### PR TITLE
Fix error when cs_arrears_date was unknown

### DIFF
--- a/docassemble/HelpForChildSupportObligors/data/questions/dbd-02-compare.yml
+++ b/docassemble/HelpForChildSupportObligors/data/questions/dbd-02-compare.yml
@@ -248,7 +248,7 @@ code: |
   # TODO: will this break any logic?
   from docassemble.base.util import DADateTime
   if cs_arrears_date_unknown:
-    cs_arrears_date = DADateTime(int(cs_arrears_year), int(cs_arrears_month), 1)
+    cs_arrears_date = as_datetime(DADateTime(int(cs_arrears_year), int(cs_arrears_month), 1))
 ---
 id: dbd 02 - catch up
 question: |


### PR DESCRIPTION
If `cs_arrears_date_unknown` is true, `cs_arrears_date` was directly set to a `DADateTime` object with no timezone info. This will later give the error "can't compare offset-naive and offset aware datetimes".

This patch runs the DADatetime through `as_datetime`, which adds the default timezone info of the server.

This issue has shown up a few times on the production server.

TBH, I remember the interview being very large and difficult to test, and I'm not sure I have the time to verify that this change fixes every instance. The best that I could do was on the python command line, importing `docassemble.base.util` and making sure that this solution fixes comparison operators.

```python
from docassemble.base.util import *
disabled_start = DADateTime(2022, 12, 1)
right_now = current_datetime()
disabled_start <= right_now
# TypeError: can't compare offset-naive and offset-aware datetimes
disabled_start_better = as_datetime(disabled_start)
disabled_start_better <= right_now
# True
```

<summary>Full error<details>
<pre>
The error message was:

TypeError: 

TypeError: can't compare offset-naive and offset-aware datetimes
In line:   if disabled_start <= cs_arrears_date <= disabled_end:

Traceback (most recent call last):
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/parse.py", line 8015, in assemble
    exec_with_trap(question, user_dict)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/parse.py", line 9366, in exec_with_trap
    exec(the_question.compute, the_dict)
  File "", line 6, in 
NameError: name 'other_considerations_complete' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/flask/app.py", line 1523, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/flask/app.py", line 1509, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/webapp/server.py", line 8061, in index
    interview.assemble(user_dict, interview_status, old_user_dict, force_question=special_question)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/parse.py", line 8296, in assemble
    raise the_error
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/parse.py", line 8083, in assemble
    question_result = self.askfor(missingVariable, user_dict, old_user_dict, interview_status, seeking=interview_status.seeking, follow_mc=follow_mc, seeking_question=seeking_question)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/parse.py", line 8746, in askfor
    exec_with_trap(question, user_dict)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/parse.py", line 9366, in exec_with_trap
    exec(the_question.compute, the_dict)
  File "", line 2, in 
TypeError: can't compare offset-naive and offset-aware datetimes

The referer URL was https://apps.suffolklitlab.org/run/child_support_obligor/

Traceback (most recent call last):
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/parse.py", line 8015, in assemble
    exec_with_trap(question, user_dict)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/parse.py", line 9366, in exec_with_trap
    exec(the_question.compute, the_dict)
  File "", line 6, in 
NameError: name 'other_considerations_complete' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/flask/app.py", line 1523, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/flask/app.py", line 1509, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/webapp/server.py", line 8061, in index
    interview.assemble(user_dict, interview_status, old_user_dict, force_question=special_question)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/parse.py", line 8296, in assemble
    raise the_error
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/parse.py", line 8083, in assemble
    question_result = self.askfor(missingVariable, user_dict, old_user_dict, interview_status, seeking=interview_status.seeking, follow_mc=follow_mc, seeking_question=seeking_question)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/parse.py", line 8746, in askfor
    exec_with_trap(question, user_dict)
  File "/usr/share/docassemble/local3.10/lib/python3.10/site-packages/docassemble/base/parse.py", line 9366, in exec_with_trap
    exec(the_question.compute, the_dict)
  File "", line 2, in 
TypeError: can't compare offset-naive and offset-aware datetimes

The external hostname was apps.suffolklitlab.org
</pre></details></summary>